### PR TITLE
Make SSH Username a variable

### DIFF
--- a/lib/fsevents_to_vm/cli.rb
+++ b/lib/fsevents_to_vm/cli.rb
@@ -6,6 +6,7 @@ module FseventsToVm
     option :debug, type: :boolean, default: false
     option :ssh_identity_file, type: :string
     option :ssh_ip, type: :string
+    option :ssh_username, type: string, default: 'docker'
     desc "start PATH",
       "Watch PATH and forward filesystem touch events to the Dinghy VM."
     def start(listen_dir = ENV['HOME'])
@@ -14,7 +15,7 @@ module FseventsToVm
       watcher = FseventsToVm::Watch.new(listen_dir)
       path_filter = FseventsToVm::PathFilter.new
       recursion_filter = FseventsToVm::RecursionFilter.new
-      forwarder = FseventsToVm::SshEmit.new(options[:ssh_identity_file], options[:ssh_ip])
+      forwarder = FseventsToVm::SshEmit.new(options[:ssh_identity_file], options[:ssh_ip], options[:ssh_username])
 
       if debug
         puts "Watching #{listen_dir} and forwarding events to Dinghy VM..."

--- a/lib/fsevents_to_vm/ssh_emit.rb
+++ b/lib/fsevents_to_vm/ssh_emit.rb
@@ -4,9 +4,10 @@ require 'tempfile'
 
 module FseventsToVm
   class SshEmit
-    def initialize(identity_file, ip)
+    def initialize(identity_file, ip, username)
       @identity_file = identity_file
       @ip = ip
+      @username = username
     end
 
     def event(event)
@@ -20,7 +21,7 @@ module FseventsToVm
     protected
 
     def ssh
-      @ssh ||= Net::SSH.start(@ip, 'docker', config: false, keys: [@identity_file])
+      @ssh ||= Net::SSH.start(@ip, @username, config: false, keys: [@identity_file])
     end
 
     def disconnect!


### PR DESCRIPTION
It still defaults to 'docker'.

I want to try this tool out with vagrant instead of docker-machine.

dinghy's solution of running a dns server is clever, but I like the simplicity of Vagrant being able to assign the same IP to the VM every time it runs which is still impossible with docker-machine.
