### PR TITLE
Only use private key in keys parameter.

### DIFF
--- a/lib/fsevents_to_vm/ssh_emit.rb
+++ b/lib/fsevents_to_vm/ssh_emit.rb
@@ -24,6 +24,7 @@ module FseventsToVm
       @ssh ||= Net::SSH.start(@ip, @username,
         config: false,
         keys: [@identity_file],
+        keys_only: true,
         paranoid: false)
     end
 


### PR DESCRIPTION
Ignore any additional keys offered by ssh-agent.

Docs for the option is here: https://net-ssh.github.io/ssh/v2/api/classes/Net/SSH.html#M000002

This fixes https://github.com/codekitchen/dinghy/issues/181
