### PR TITLE
Follow symlinks when copying to /bin

### DIFF
--- a/lib/fsevents_to_vm/ssh_install_gnu_touch.rb
+++ b/lib/fsevents_to_vm/ssh_install_gnu_touch.rb
@@ -6,7 +6,7 @@ module FseventsToVm
 
     INSTALL_COMMAND =
       'CONTAINER_ID=$(docker create codekitchen/dinghy-http-proxy:2.5) '\
-      '&& sudo docker cp ${CONTAINER_ID}:/bin/touch /bin/gtouch ' \
+      '&& sudo docker cp -L ${CONTAINER_ID}:/bin/touch /bin/gtouch ' \
       '&& docker rm ${CONTAINER_ID} && echo "Installed GNU touch"'
 
     INSTALL_COMMAND_SUCCEEDED = /Installed GNU touch/


### PR DESCRIPTION
On rancherOS `/bin` is a symlink to `/usr/bin`.  Adding `-L` causes `docker cp` to follow that symlink.  Without it, we get a `not a directory` error and fsevents fails to start.